### PR TITLE
Update post-setup message to recommend `task deploy` instead of `task deploy-dev`

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -35,7 +35,7 @@ tasks:
       - dr dotenv setup --if-needed
       - task install
       - task infra:start
-      - echo '✅ You are all set. Run `task dev` to start developing, or run `task deploy-dev` to deploy to DataRobot.'
+      - echo '✅ You are all set. Run `task dev` to start developing, or run `task deploy` to deploy to DataRobot.'
 
   lint:
     desc: "🧹 Run linters"


### PR DESCRIPTION
# Summary

fix: update post-setup message to recommend `task deploy` instead of `task deploy-dev`

# Rationale

Since dr start already executes task infra:start → task deploy-dev, recommending task deploy-dev again in the post-setup message is misleading. It is more appropriate to suggest task deploy (full deployment) instead.

# Checklist
- [ ] Implementation
- [ ] Update Changelog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a user-facing message change in `Taskfile.yaml` with no impact to task execution or deployment behavior.
> 
> **Overview**
> Updates the `start` task’s final echo in `Taskfile.yaml` to direct users to run `task deploy` (full deployment) rather than `task deploy-dev` after setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 426b9ddb47fe728f4541beddc3807aed25b52282. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->