### PR TITLE
unblock CLI transfer chat history script from hanging due to telemetry

### DIFF
--- a/core/src/core/persistent_storage.py
+++ b/core/src/core/persistent_storage.py
@@ -47,7 +47,9 @@ class AsyncDataRobotClient:
     def __init__(self, token: str, endpoint: str):
         normalized_endpoint = (endpoint or "").rstrip("/") + "/"
         self._client = httpx.AsyncClient(
-            base_url=normalized_endpoint, headers={"Authorization": f"Bearer {token}"}
+            base_url=normalized_endpoint,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=httpx.Timeout(60.0, connect=30.0),
         )
 
     async def unpaginate(
@@ -59,7 +61,10 @@ class AsyncDataRobotClient:
             yield row
         while resp_data.get("next") is not None:
             next_url = resp_data["next"]
-            r = await self._client.get(next_url, params=initial_params)
+            # next_url is an absolute URL that already contains the query
+            # string; passing initial_params again duplicates entityId/
+            # entityType in the URL and can confuse the server.
+            r = await self._client.get(next_url)
             resp_data = r.json()
             for row in resp_data["data"]:
                 yield row

--- a/core/src/core/telemetry/otel.py
+++ b/core/src/core/telemetry/otel.py
@@ -207,8 +207,11 @@ class OTel:
         # We keep this even if telemetry is disabled, just in case something tries to force it
         self._install_otlp_error_filter()
 
-        # Setup auto-instrumentation on first init
-        if not self._auto_instrumentation_setup:
+        # Setup auto-instrumentation on first init.
+        # Skip when telemetry is disabled: the httpx instrumentor wraps every
+        # AsyncClient process-wide and can hang KeyValue pagination in CLI
+        # scripts that set DISABLE_TELEMETRY=true (no exporter configured).
+        if self.telemetry_enabled and not self._auto_instrumentation_setup:
             self._setup_auto_instrumentation()
             self._auto_instrumentation_setup = True
 

--- a/core/tests/test_persistent_storage.py
+++ b/core/tests/test_persistent_storage.py
@@ -44,11 +44,18 @@ async def test_iter_key_value(httpx_async_client: AsyncMock) -> None:
         x.json.return_value = v
         return x
 
-    async def get_key_values(path: str, *, params: dict[str, Any]) -> Any:
-        assert params == {"entityId": "e", "entityType": "customApplication"}
+    async def get_key_values(
+        path: str, *, params: dict[str, Any] | None = None
+    ) -> Any:
         if path == "keyValues/":
+            # Initial page: params are explicitly passed by unpaginate().
+            assert params == {"entityId": "e", "entityType": "customApplication"}
             return r({"data": [1, 2], "next": "keyValues/next/"})
         elif path == "keyValues/next/":
+            # Subsequent pages: the server's `next` URL already contains the
+            # original query string, so unpaginate() must NOT re-pass params
+            # (doing so duplicates entityId/entityType in the URL).
+            assert params is None
             return r(
                 {
                     "data": [3],
@@ -67,6 +74,23 @@ async def test_iter_key_value(httpx_async_client: AsyncMock) -> None:
         key_values.append(key_value)
 
     assert key_values == [1, 2, 3]
+
+
+def test_async_client_uses_explicit_timeout(httpx_async_client: AsyncMock) -> None:
+    """``AsyncDataRobotClient`` must construct ``httpx.AsyncClient`` with an
+    explicit timeout. Without one, calls inherit httpx's default of 5 seconds,
+    and when the OTEL httpx instrumentor is installed process-wide a default
+    timeout can be masked altogether — leading to silent indefinite hangs on
+    the KeyValue listing endpoint in long-running CLI tools.
+    """
+    AsyncDataRobotClient(token="t", endpoint="https://dr.example")
+
+    httpx_async_client.assert_called_once()
+    _, kwargs = httpx_async_client.call_args
+    assert (
+        "timeout" in kwargs
+    ), "AsyncDataRobotClient must pass an explicit timeout to httpx.AsyncClient"
+    assert isinstance(kwargs["timeout"], httpx.Timeout)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
These 3 items interact to hang `task core:transfer-database` (and any CLI script that sets DISABLE_TELEMETRY=true) on custom applications with >100 KeyValues:
1. otel.py installs httpx auto-instrumentation unconditionally even when telemetry_enabled is False, leading to silent indefinite hangs on async pagination in scripts that explicitly opt out of telemetry.
2. AsyncDataRobotClient creates httpx.AsyncClient without an explicit timeout, leaving no backstop against a masked default.
3. unpaginate re-applies initial_params to subsequent absolute next URLs, duplicating entityId/entityType in the URL on every page after the first.

Production behavior is unchanged: with OTEL_EXPORTER_OTLP_ENDPOINT set,  telemetry_enabled is True and the instrumentor still installs.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTTP client, pagination, and global OTEL httpx instrumentation; production paths with OTLP still instrument, but behavior changes for disabled-telemetry and multi-page KeyValue listing.
> 
> **Overview**
> Fixes **CLI hangs** (e.g. `task core:transfer-database`) when listing many KeyValues with `DISABLE_TELEMETRY=true`.
> 
> **`AsyncDataRobotClient`**: adds an explicit **60s / 30s connect** `httpx` timeout, and **`unpaginate`** stops re-sending `initial_params` on server `next` URLs so `entityId` / `entityType` are not duplicated in the query string.
> 
> **`OTel`**: runs **httpx auto-instrumentation only when telemetry is enabled**, so opt-out CLI processes are not wrapped process-wide in a way that can stall async KeyValue pagination.
> 
> Tests cover pagination params on follow-up pages and that the async client always passes a timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45ccb4f045726fa51c995a974df361c32153898. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->